### PR TITLE
fix(ci): add sudo to bats install

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install BATS
-        run: npm install -g bats
+        run: sudo npm install -g bats
 
       - name: Run BATS tests
         run: bats tests/unit/


### PR DESCRIPTION
## Summary

- Fix EACCES permission error in BATS workflow — `npm install -g bats` needs `sudo` on GitHub runners

## Test plan

- [ ] BATS workflow passes (13/13 tests green)

Generated with Claude <noreply@anthropic.com>