### PR TITLE
fix(ci): add workflow permissions and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Test Action](https://github.com/qte77/gha-llms-txt-action/actions/workflows/test-action.yaml/badge.svg)
 ![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-llms-txt-action/badge)
 ![CodeQL](https://github.com/qte77/gha-llms-txt-action/actions/workflows/codeql.yaml/badge.svg)
-![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c)
+[![Dependabot Updates](https://github.com/qte77/gha-llms-txt-action/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/gha-llms-txt-action/actions/workflows/dependabot/dependabot-updates)
 ![BATS](https://github.com/qte77/gha-llms-txt-action/actions/workflows/bats.yaml/badge.svg)
 
 Composite GitHub Action that generates `llms.txt` from a template using `envsubst`, optionally opening a pull request with the results.


### PR DESCRIPTION
## Summary

- **fix(ci):** Add explicit `permissions: contents: read` to bats workflow, resolving [code scanning alert #2](https://github.com/qte77/gha-llms-txt-action/security/code-scanning/2)
- **ci:** Add `dependabot.yml` for weekly github-actions updates
- **docs:** Update README dependabot badge to link to workflow status

## Test plan

- [ ] Verify bats workflow still passes with restricted permissions
- [ ] Confirm dependabot picks up the config and creates update PRs
- [ ] Check README badge renders correctly

Generated with Claude <noreply@anthropic.com>